### PR TITLE
Change getPrefix method visibility to public

### DIFF
--- a/src/PDOdb.php
+++ b/src/PDOdb.php
@@ -340,7 +340,7 @@ final class PDOdb
         $this->prefix[$this->defConnectionName] = $prefix;
     }
 
-    protected function getPrefix(): string
+    public function getPrefix(): string
     {
         return $this->prefix[$this->defConnectionName] ?? '';
     }


### PR DESCRIPTION
Make the `getPrefix` method public to get the current prefix. This is required if using raw queries to have the possibility to fetch the current prefix. Otherwise the prefix must be hardcoded.