### PR TITLE
Change final class PDOdb to non-final

### DIFF
--- a/src/PDOdb.php
+++ b/src/PDOdb.php
@@ -33,7 +33,7 @@ namespace decMuc\PDOdb;
 if (!defined('PDOdb_HEURISTIC_WHERE_CHECK')) {
     define('PDOdb_HEURISTIC_WHERE_CHECK', true);
 }
-final class PDOdb
+class PDOdb
 {
 
 


### PR DESCRIPTION
Make the class as non-final because of allow extend the class. At the moment you got the error 

```Fatal error: Class CLASSNAME cannot extend final class decMuc\PDOdb\PDOdb in PATH on line 19```

The documentation mention here, that extend the class should be possible:
https://docspdodb.decmuc.dev/content/02_initialization/extended.html