### PR TITLE
error handling and WHERE group conditions

### DIFF
--- a/src/PDOdb.php
+++ b/src/PDOdb.php
@@ -2327,6 +2327,44 @@ final class PDOdb
 
         return $this;
     }
+	
+	/**
+     * Adds a marker to open a where Group
+     *
+     * @param string $operator Concat operator (defaults to AND')
+     * @return self
+     */
+	public function openWhereGroup(string $operator = 'AND'): self
+	{
+		$this->_where[] = ['__group_open' => true, 'operator' => strtoupper($operator)];
+		return $this;
+	}
+	
+	/**
+     * Adds a marker to close a where Group
+     *
+     * @return self
+     */
+	public function closeWhereGroup(): self
+	{
+		$this->_where[] = ['__group_close' => true];
+		return $this;
+	}
+	
+	/**
+     * Adds a complete where group with a callback.
+     *
+     * @param callable $cb Callback to perform inside the group
+     * @param string $operator Concat operator (defaults to AND')
+     * @return self
+     */
+	public function whereGroup(callable $cb, string $operator = 'AND'): self
+	{
+		$this->openWhereGroup($operator);
+		$cb($this);
+		$this->closeWhereGroup();
+		return $this;
+	}
 
     /**
      * Adds a WHERE condition to the query builder.


### PR DESCRIPTION
With this PR, it is now possible to group WHERE conditions. This is necessary for more complex WHERE conditions so that RAW queries do not always have to be used.

**Examples:**

Query:
```php

#Query:
#Beginning with normal condition
$db->whereInt('age', 18, '>=')
	->openWhereGroup('AND')
		->whereString('country', 'DE')
		->orWhereString('country', 'AT')
	->closeWhereGroup()
	->orWhereInt('is_admin', 1)
	->get('users');

#Result:
SELECT * FROM users WHERE age >= '18' AND (country = 'DE' OR country = 'AT') OR is_admin = '1'

#Query:
#Beginning with group
$db->openWhereGroup('AND')
		->whereString('country', 'DE')
		->orWhereString('country', 'AT')
		->whereInt('age', 18, '>=')
	->closeWhereGroup()
	->orWhereInt('is_admin', 1)
	->get('users');

#Result:
SELECT * FROM users WHERE (country = 'DE' OR country = 'AT' AND age >= '18') OR is_admin = '1'

#Query:
#Group inside another Group
$db->whereInt('age', 18, '>=')
	->openWhereGroup('OR')
		->whereString('country', 'DE')
		->orWhereString('country', 'AT')
		->openWhereGroup('AND')
			->whereString('city', 'Berlin')
			->whereString('number', '16')
		->closeWhereGroup()
	->closeWhereGroup()
	->orWhereInt('is_admin', 1)	
	->get('users');

#Result:
SELECT * FROM users WHERE age >= '18' OR (country = 'DE' OR country = 'AT' AND (city = 'Berlin' AND number = '16')) OR is_admin = '1'

```

I have already prepared unit tests for this. However, this requires a redesign of the library, as final classes cannot be mocked and the database connection is already established in the constructor. Here, it is necessary to introduce a parameter that prevents a database connection from being established.