### PR TITLE
Skip decimal normalization for LOBs and non-UTF8

### DIFF
--- a/src/PDOdb.php
+++ b/src/PDOdb.php
@@ -3860,20 +3860,25 @@ final class PDOdb
     protected function _bindParam(mixed $value): void
     {
         if (is_array($value) && isset($value['value'], $value['type'])) {
-            $value['value'] = $this->_normalizeDecimalStringSimple($value['value']);
+			if($value['type'] !== \PDO::PARAM_LOB) {
+				$value['value'] = $this->_normalizeDecimalStringSimple($value['value']);
+			}
             $this->_bindParams[] = $value;
             return;
         }
 
-        $value = $this->_normalizeDecimalStringSimple($value);
-
         static $typeMap = [
-            'integer' => \PDO::PARAM_INT,
-            'boolean' => \PDO::PARAM_BOOL,
-            'NULL'    => \PDO::PARAM_NULL,
+            'integer' 	=> \PDO::PARAM_INT,
+            'boolean' 	=> \PDO::PARAM_BOOL,
+            'NULL'    	=> \PDO::PARAM_NULL,
+            'ressource' => \PDO::PARAM_LOB,
         ];
 
         $type = $typeMap[gettype($value)] ?? \PDO::PARAM_STR;
+		
+		if($type !== \PDO::PARAM_LOB) {
+			$value = $this->_normalizeDecimalStringSimple($value);
+		}
 
         $this->_bindParams[] = [
             'value' => $value,
@@ -6319,6 +6324,10 @@ final class PDOdb
             return $s === '' ? '0' : $s;
         }
         if (!is_string($value)) return $value;
+		
+		if(!mb_check_encoding($value, 'UTF-8')) {
+			return $value;
+		}
 
         $s = trim($value);
         if ($s === '') return $value;


### PR DESCRIPTION
Avoid normalizing decimal strings for PDO::PARAM_LOB values when binding parameters (both array-style params and scalar params). Add a 'ressource' => PDO::PARAM_LOB entry to the type map and defer normalization until after determining the PDO param type. Also skip normalization for strings that are not valid UTF-8 (checked with mb_check_encoding) to prevent corrupting binary/non-UTF8 data.

fixes #16 